### PR TITLE
Add serialization to model classes

### DIFF
--- a/src/main/java/src/java/model/Documento.java
+++ b/src/main/java/src/java/model/Documento.java
@@ -4,11 +4,13 @@ package model;
 
 import java.time.LocalDate;
 import java.io.File;
+import java.io.Serializable;
 
 /**
  * Rappresenta un documento caricato per un hackathon.
  */
-public class Documento {
+public class Documento implements Serializable {
+    private static final long serialVersionUID = 1L;
     private LocalDate data;
     private String contenuto;
     private File file;

--- a/src/main/java/src/java/model/Hackathon.java
+++ b/src/main/java/src/java/model/Hackathon.java
@@ -4,8 +4,10 @@ package model;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.io.Serializable;
 
-public class Hackathon {
+public class Hackathon implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String titolo;
     private String sede;
     private LocalDateTime dataInizio;

--- a/src/main/java/src/java/model/Invito.java
+++ b/src/main/java/src/java/model/Invito.java
@@ -3,11 +3,13 @@
 package model;
 
 import java.time.LocalDate;
+import java.io.Serializable;
 
 /**
  * Invito ad un hackathon per un partecipante.
  */
-public class Invito {
+public class Invito implements Serializable {
+    private static final long serialVersionUID = 1L;
     public enum Stato { INVIATO, ACCETTATO, RIFIUTATO }
 
     private final Hackathon hackathon;

--- a/src/main/java/src/java/model/Team.java
+++ b/src/main/java/src/java/model/Team.java
@@ -5,8 +5,10 @@ package model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.io.Serializable;
 
-public class Team {
+public class Team implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String nome;
     private final List<Partecipante> partecipanti = new ArrayList<>();
     private int voto = -1;

--- a/src/main/java/src/java/model/Voto.java
+++ b/src/main/java/src/java/model/Voto.java
@@ -3,11 +3,13 @@
 package model;
 
 import java.util.Objects;
+import java.io.Serializable;
 
 /**
  * Rappresenta un voto assegnato a un team.
  */
-public class Voto {
+public class Voto implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final Team team;
     private final int punteggio;
 


### PR DESCRIPTION
## Summary
- make `Documento`, `Hackathon`, `Invito`, `Team` and `Voto` serializable
- add `serialVersionUID` fields

## Testing
- `javac -d out @/tmp/files_compile.txt`
- `java -cp out:. SerializeTest`

------
https://chatgpt.com/codex/tasks/task_e_685b4361cf648329a21cbb8dc742acb4