### PR TITLE
Add Maven compiler plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,5 +13,18 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
## Summary
- add Maven compiler plugin configuration with JDK 21 target

## Testing
- `mvn package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685b4363806c8329b467061082fcdd36