### PR TITLE
Fix missing File import in DocumentoGUI

### DIFF
--- a/src/main/java/src/java/gui/DocumentoGUI.java
+++ b/src/main/java/src/java/gui/DocumentoGUI.java
@@ -6,6 +6,7 @@ import model.Hackathon;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.File;
 
 public class DocumentoGUI extends JFrame {
     private final Controller controller;


### PR DESCRIPTION
## Summary
- include `java.io.File` import to resolve compiler error in `DocumentoGUI`

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b45f728608329b538c6c761125e6d