### PR TITLE
Update README with JDBC driver notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ If you prefer a manual compilation, use `javac`:
 ```bash
 mkdir -p out
 javac -d out $(find src/main/java -name "*.java")
-java -cp out model.Main
+# Include the PostgreSQL driver when running manually
+java -cp out:$HOME/.m2/repository/org/postgresql/postgresql/42.7.2/postgresql-42.7.2.jar model.Main
 ```
 
 The application now uses a PostgreSQL database. Configure the connection using the
 `DB_URL`, `DB_USER` and `DB_PASS` environment variables if the defaults do not
-match your setup.
+match your setup. Ensure that the PostgreSQL JDBC driver is on the classpath when
+running the application.


### PR DESCRIPTION
## Summary
- document that PostgreSQL JDBC driver must be on the classpath
- show how to run manual `javac` example with the driver

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ca05e428883298bbeac255e70ed5f